### PR TITLE
docs: add community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,15 @@
 This is the repository for Web3MQ's documentation.
 
 
-## Instal
+## Install
+
+Use [pnpm](https://pnpm.io/) to save your disk space
+
+```bash
+pnpm install
+```
+
+OR
 
 ```bash
 yarn
@@ -14,5 +22,7 @@ yarn install
 ## Run
 
 ```bash
+pnpm start
+# or
 yarn run start
 ```

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -75,14 +75,14 @@ const config = {
               //   label: 'Stack Overflow',
               //   href: 'https://stackoverflow.com/questions/tagged/docusaurus',
               // },
-              // {
-              //   label: 'Discord',
-              //   href: 'https://discordapp.com/invite/docusaurus',
-              // },
-              // {
-              //   label: 'Twitter',
-              //   href: 'https://twitter.com/docusaurus',
-              // },
+              {
+                label: 'Discord',
+                href: 'https://discord.gg/UymwsCAb',
+              },
+              {
+                label: 'Twitter',
+                href: 'https://twitter.com/Web3MQ',
+              },
             ],
           },
           {
@@ -93,7 +93,7 @@ const config = {
               //   to: '/blog',
               // },
               {
-                label: 'This Website is build with Docusaurus and love❤️',
+                label: 'Built with Docusaurus and ❤️',
                 href: 'https://github.com/facebook/docusaurus',
               },
             ],

--- a/src/components/IntroPage/IntroPage.tsx
+++ b/src/components/IntroPage/IntroPage.tsx
@@ -67,7 +67,7 @@ export const IntroPage = () => {
                 {card.description}
               </div>
               <div style={{display: 'flex', height: '100%', flexDirection: 'column', justifyContent: 'end', marginTop: '16px'}}>
-                <Link className={ss.cardLink} to={card.href}>Get Started with {card.title} -&gt;</Link>
+                <Link className={ss.cardLink} to={card.href}>Get Started with {card.title} &#8594;</Link>
               </div>
             </div>
           ))}


### PR DESCRIPTION
* Adds pnpm install option to Documentation README
* Adds Discord and Twitter community links in footer 
* Replaces "->" with an ASCII arrow. This removes the possibility for a line break between the hyphen and greater than symbol.
